### PR TITLE
Set up TMDB API token configuration and environment variables

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,3 +7,4 @@ import os
 class Config:
   SECRET_KEY = 'my-secret-key'                                  # Used by Flask to secure sessions and other things
   SQLALCHEMY_DATABASE_URI = 'sqlite:///app.db'    # Tells Flask-SQLAlchemy where the database is located
+  TMDB_ACCESS_TOKEN=os.getenv('TMDB_ACCESS_TOKEN')  # Get the TMDB API token from .env file

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ itsdangerous==2.2.0
 Jinja2==3.1.6
 Mako==1.3.12
 MarkupSafe==3.0.3
+python-dotenv==1.2.2
 SQLAlchemy==2.0.49
 typing_extensions==4.15.0
 Werkzeug==3.1.8

--- a/run.py
+++ b/run.py
@@ -1,4 +1,8 @@
 # Entry point for the application
 from app import app
+from config import Config
+
+print("TMDB Token loaded:", Config.TMDB_ACCESS_TOKEN is not None)  # Check if the TMDB token is loaded correctly
+
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
In `config.py`
- Added variable `TMDB_ACCESS_TOKEN=os.getenv('TMDB_ACCESS_TOKEN')` to automatically get the TMDB API from our `.env` file

In `requirements.txt`
- Added `python-dotenv` in the list of install requirements

In `run.py`
- Added simple print command as debug for when token is not loaded