### PR TITLE
Fixed indent issue in rotues and fixed problematic css link in home page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -394,8 +394,8 @@ def movie_detail_api(movie_id):
 #=================================================
 @app.route('/api/reviews/recent')
 def recent_reviews():
-   # Query the 5 most recent reviews ordere by review ID descending
-   results = Review.query.order_by(Review.id.desc()).limit(5).all()
+    # Query the 5 most recent reviews ordere by review ID descending
+    results = Review.query.order_by(Review.id.desc()).limit(5).all()
 
     reviews = [
         {
@@ -408,7 +408,7 @@ def recent_reviews():
         for r in results
     ]
 
-   return jsonify(reviews)
+    return jsonify(reviews)
 
 
 #=================================================

--- a/app/templates/home_page.html
+++ b/app/templates/home_page.html
@@ -19,15 +19,18 @@
       rel="stylesheet"
       href="{{ url_for('static', filename='css/home_page.css') }}"
     />
+        <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/movie_card.css') }}"
+    />
     <link
       rel="stylesheet"
       href="{{ url_for('static', filename='css/footer.css') }}"
     />
-    <link
+        <link
       rel="icon"
       type="image/png"
       href="{{ url_for('static', filename='images/favicon.png') }}"
-      href="{{ url_for('static', filename='css/movie_card.css') }}"
     />
     <title>Home Page</title>
   </head>


### PR DESCRIPTION
1. There was an indentation issue in `routes.py`. Fixed
2. Related to #111. Problem was caused due to a mixed up in a `<link>` element in <head>`. A link to `movie_card.css` was combined with link for icons. Solved by splitting them up